### PR TITLE
DDF-475 Move to PowerMock 1.5.4, for compatibility with Mockito 1.9.5

### DIFF
--- a/pep/security-pep-interceptor/pom.xml
+++ b/pep/security-pep-interceptor/pom.xml
@@ -25,6 +25,10 @@
   <name>DDF :: Security :: PEP :: Interceptor</name>
   <packaging>bundle</packaging>
 
+  <properties>
+      <powermock.version>1.5.4</powermock.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.shiro</groupId>
@@ -47,13 +51,13 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.4.12</version>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.4.12</version>
+      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This is one of three pull requests that need to be applied / rejected as a set. The other two are in ddf-catalog and ddf-parent.

The need for this pull request is driven by Oracle JDK8 compatibility for ddf-catalog, which requires PowerMock to be upgraded to 1.5.4 for one particular call (related to constructor mocking with arguments).

PowerMock versions need to match Mockito versions (see Supported Versions table at https://code.google.com/p/powermock/wiki/MockitoUsage13). The upgrade to PowerMock 1.5.4 requires upgrading Mockito to at least 1.9.5 (which is the latest released version). Mockito version is in ddf-platform.

That (in turn) requires upgrading the PowerMock version in ddf-security to at least 1.5.4.

Unfortunately, travis-CI is going to show breakage because the changes aren't all being applied together.
