### PR TITLE
Pull request for DDF-891

### DIFF
--- a/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
+++ b/pep/security-pep-interceptor/src/main/java/ddf/security/pep/interceptor/PEPAuthorizingInterceptor.java
@@ -15,7 +15,6 @@
 package ddf.security.pep.interceptor;
 
 import java.io.StringWriter;
-import java.util.List;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.OutputKeys;
@@ -26,16 +25,17 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.cxf.headers.Header;
-import org.apache.cxf.helpers.CastUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.binding.soap.model.SoapOperationInfo;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.security.AccessDeniedException;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
-import org.apache.cxf.transport.http.AbstractHTTPDestination;
-import org.apache.cxf.transport.servlet.AbstractHTTPServlet;
-import org.codice.ddf.security.policy.context.ContextPolicy;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.ws.addressing.JAXWSAConstants;
+import org.apache.cxf.ws.addressing.Names;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
@@ -48,7 +48,6 @@ import ddf.security.permission.ActionPermission;
 import ddf.security.service.SecurityManager;
 import ddf.security.service.SecurityServiceException;
 import ddf.security.service.impl.SecurityAssertionStore;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Interceptor used to perform service authentication.
@@ -57,9 +56,6 @@ import javax.servlet.http.HttpServletRequest;
 public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message> {
 
     private Logger logger = LoggerFactory.getLogger(PEPAuthorizingInterceptor.class);
-
-    private static final QName SOAP_ACTION = new QName("http://www.w3.org/2005/08/addressing",
-            "Action");
 
     private SecurityManager securityManager;
 
@@ -95,6 +91,9 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
             if ((assertion != null) && (assertion.getSecurityToken() != null)) {
                 Subject user = null;
                 ActionPermission action = null;
+                
+                String actionURI = getActionUri(message);
+                
                 try {
                     user = securityManager.getSubject(assertion.getSecurityToken());
                     if (user == null) {
@@ -109,19 +108,18 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
                     logger.debug("Checking for permission");
                     SecurityLogger.logInfo("Is user [" + user.getPrincipal() + "] authenticated: "
                             + user.isAuthenticated());
-                    List<Header> headers = CastUtils
-                            .cast((List<?>) message.get(Header.HEADER_LIST));
-                    if (headers != null) {
-                        for (Header curHeader : headers) {
-                            if (curHeader.getName().equals(SOAP_ACTION)) {
-                                action = new ActionPermission(
-                                        ((Element) curHeader.getObject()).getTextContent());
-                                logger.debug("Action Permission: " + ((Element) curHeader.getObject()).getTextContent());
-                                break;
-                            }
-                        }
-                        isPermitted = user.isPermitted(action);
+                    
+                    if (StringUtils.isEmpty(actionURI)) {
+                        logger.info("Denying access : unable to determine action for {}", user.getPrincipal());
+                        SecurityLogger.logWarn("Denying access to [" + user.getPrincipal() + "] for unknown action.");
+                    	throw new AccessDeniedException("Unauthorized");
                     }
+                    
+                    action = new ActionPermission(actionURI);
+                    logger.debug("Action Permission: " + action);
+                    
+                    isPermitted = user.isPermitted(action);
+                    
                     logger.debug("Result of permission: {}", isPermitted);
                     SecurityLogger.logInfo("Is user [" + user.getPrincipal() + "] permitted: "
                             + isPermitted);
@@ -131,24 +129,14 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
                             SecurityConstants.SAML_ASSERTION);
                 } catch (SecurityServiceException e) {
                     logger.warn("Caught exception when trying to perform AuthZ.", e);
-                    if (action != null) {
-                        SecurityLogger.logWarn(
-                            "Denying access : Caught exception when trying to perform AuthZ for user ["
-                            + user.getPrincipal() + "] for service " + action.getAction(), e);
-                    } else {
-                        SecurityLogger.logWarn(
-                            "Denying access : Caught exception when trying to perform AuthZ for user ["
-                            + user.getPrincipal() + "] for unknown service.", e);
-                    }
+                    SecurityLogger.logWarn(
+                            "Denying access : Caught exception when trying to authenticate user for service [" + actionURI + "]", e);
                     throw new AccessDeniedException("Unauthorized");
                 }
                 if (!isPermitted) {
                     if (action != null) {
                         logger.info("Denying access to {} for service {}", user.getPrincipal(), action.getAction());
                         SecurityLogger.logWarn("Denying access to [" + user.getPrincipal() + "] for service " + action.getAction());
-                    } else {
-                        logger.info("Denying access to {} for unknown service", user.getPrincipal());
-                        SecurityLogger.logWarn("Denying access to [" + user.getPrincipal() + "] for unknown service ");
                     }
                     throw new AccessDeniedException("Unauthorized");
                 }
@@ -161,7 +149,76 @@ public class PEPAuthorizingInterceptor extends AbstractPhaseInterceptor<Message>
             throw new AccessDeniedException("Unauthorized");
         }
     }
+    
+    private String getActionUri(Message message) {
+    	String actionURI = null;
+    	
+        /**
+         *  See if the action is explicitly defined in the WSDL message service model.
+         *  Retrieves one of the Action attribute in the wsdl:input message.
+         */
+		MessageInfo msgInfo = (MessageInfo) message.get(MessageInfo.class.getName());
+		if (msgInfo != null && msgInfo.getExtensionAttributes() != null) {
+			Object attr = msgInfo.getExtensionAttribute(JAXWSAConstants.WSAW_ACTION_QNAME);
+			if (attr == null) {
+				attr = msgInfo.getExtensionAttributes().get(
+						new QName(Names.WSA_NAMESPACE_WSDL_METADATA, Names.WSAW_ACTION_NAME));
+			}
+			if (attr == null) {
+				attr = msgInfo.getExtensionAttributes().get(new QName(JAXWSAConstants.NS_WSA, Names.WSAW_ACTION_NAME));
+			}
+			if (attr == null) {
+				attr = msgInfo.getExtensionAttributes().get(
+						new QName(Names.WSA_NAMESPACE_WSDL_NAME_OLD, Names.WSAW_ACTION_NAME));
+			}
+			if (attr instanceof QName) {
+				actionURI = ((QName) attr).getLocalPart();
+			} else {
+				actionURI = attr == null ? null : attr.toString();
+			}
+		}
+        
+        /**
+         * See if the action is explicitly defined in the WSDL operation service model.
+         * Retrieves the operation soap:soapAction property.
+         */
+		if (StringUtils.isEmpty(actionURI)) {
+			BindingOperationInfo bindingOpInfo = message.getExchange().get(BindingOperationInfo.class);
+			SoapOperationInfo soi = bindingOpInfo.getExtensor(SoapOperationInfo.class);
+			if (soi == null && bindingOpInfo.isUnwrapped()) {
+				soi = bindingOpInfo.getWrappedOperation().getExtensor(SoapOperationInfo.class);
+			}
+			actionURI = soi == null ? null : soi.getAction();
+			actionURI = StringUtils.isEmpty(actionURI) ? null : actionURI;
+		}
+		
+		/**
+		 * If the service model doesn't explicitly defines the action,
+		 * we'll construct the standard URI string.
+		 */
+		if (StringUtils.isEmpty(actionURI)) {
+			QName op = (QName) message.get("javax.xml.ws.wsdl.operation");
+			QName port = (QName) message.get("javax.xml.ws.wsdl.port");
+			if (op != null && port != null) {
+				actionURI = port.getNamespaceURI();
+				actionURI = addPath(actionURI, port.getLocalPart());
+				actionURI = addPath(actionURI, op.getLocalPart() + "Request");
+			}
+		}
+		
+		return actionURI;
+    }
 
+    private String addPath(String uri, String path) {
+        StringBuilder builder = new StringBuilder(uri);
+        String delimiter = uri.startsWith("urn") ? ":" : "/";
+        if (!uri.endsWith(delimiter) && !path.startsWith(delimiter)) {
+            builder.append(delimiter);
+        }
+        builder.append(path);
+        return builder.toString();
+    }
+    
     private String format(Element unformattedXml) {
         if (unformattedXml == null) {
             logger.error("Unable to transform xml: null");

--- a/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorActions.java
+++ b/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorActions.java
@@ -14,9 +14,12 @@
  **/
 package ddf.security.pep.interceptor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +50,7 @@ import ddf.security.service.SecurityServiceException;
 import ddf.security.service.impl.SecurityAssertionStore;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ SecurityAssertionStore.class, SecurityLogger.class })
+@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class TestPepInterceptorActions {
 
     @Test
@@ -65,13 +68,14 @@ public class TestPepInterceptorActions {
 
         PowerMockito.mockStatic(SecurityAssertionStore.class);
         PowerMockito.mockStatic(SecurityLogger.class);
-        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(mockSecurityAssertion);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(
+                mockSecurityAssertion);
         // SecurityLogger is already stubbed out
         when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
         when(mockSecurityToken.getToken()).thenReturn(null);
 
         when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
-        
+
         QName op = new QName("urn:catalog:query", "search", "ns1");
         QName port = new QName("urn:catalog:query", "query-port", "ns1");
         when(messageWithAction.get("javax.xml.ws.wsdl.operation")).thenReturn(op);
@@ -82,22 +86,22 @@ public class TestPepInterceptorActions {
         when(messageWithAction.getExchange()).thenReturn(mockExchange);
         when(mockExchange.get(BindingOperationInfo.class)).thenReturn(mockBOI);
         when(mockBOI.getExtensor(SoapOperationInfo.class)).thenReturn(null);
-        
+
         doAnswer(new Answer<Boolean>() {
-			@Override
-			public Boolean answer(InvocationOnMock invocation) throws Throwable {
-				ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
-				assertEquals("urn:catalog:query:query-port:searchRequest", perm.getAction());
-				return true;
-			}
-		}).when(mockSubject).isPermitted(isA(ActionPermission.class));
-        
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
+                assertEquals("urn:catalog:query:query-port:searchRequest", perm.getAction());
+                return true;
+            }
+        }).when(mockSubject).isPermitted(isA(ActionPermission.class));
+
         // This should work.
         interceptor.handleMessage(messageWithAction);
 
         PowerMockito.verifyStatic();
     }
-    
+
     @Test
     public void testMessageWithMessageAction() throws SecurityServiceException {
         PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
@@ -113,35 +117,35 @@ public class TestPepInterceptorActions {
 
         PowerMockito.mockStatic(SecurityAssertionStore.class);
         PowerMockito.mockStatic(SecurityLogger.class);
-        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(mockSecurityAssertion);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(
+                mockSecurityAssertion);
         // SecurityLogger is already stubbed out
         when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
         when(mockSecurityToken.getToken()).thenReturn(null);
 
         when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
-        
-		Map<QName, Object> extensionMap = new HashMap<>();
-		extensionMap.put(new QName(Names.WSA_NAMESPACE_WSDL_METADATA, Names.WSAW_ACTION_NAME),
-				"urn:catalog:query:query-port:search");
-		MessageInfo mockMessageInfo = mock(MessageInfo.class);
-		when(messageWithAction.get(MessageInfo.class.getName())).thenReturn(mockMessageInfo);
-		when(mockMessageInfo.getExtensionAttributes()).thenReturn(extensionMap);
-        
+
+        Map<QName, Object> extensionMap = new HashMap<QName, Object>();
+        extensionMap.put(new QName(Names.WSA_NAMESPACE_WSDL_METADATA, Names.WSAW_ACTION_NAME),
+                "urn:catalog:query:query-port:search");
+        MessageInfo mockMessageInfo = mock(MessageInfo.class);
+        when(messageWithAction.get(MessageInfo.class.getName())).thenReturn(mockMessageInfo);
+        when(mockMessageInfo.getExtensionAttributes()).thenReturn(extensionMap);
+
         doAnswer(new Answer<Boolean>() {
-			@Override
-			public Boolean answer(InvocationOnMock invocation) throws Throwable {
-				ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
-				assertEquals("urn:catalog:query:query-port:search", perm.getAction());
-				return true;
-			}
-		}).when(mockSubject).isPermitted(isA(ActionPermission.class));
-        
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
+                assertEquals("urn:catalog:query:query-port:search", perm.getAction());
+                return true;
+            }
+        }).when(mockSubject).isPermitted(isA(ActionPermission.class));
+
         // This should work.
         interceptor.handleMessage(messageWithAction);
 
         PowerMockito.verifyStatic();
     }
-    
 
     @Test
     public void testMessageWithOperationAction() throws SecurityServiceException {
@@ -158,7 +162,8 @@ public class TestPepInterceptorActions {
 
         PowerMockito.mockStatic(SecurityAssertionStore.class);
         PowerMockito.mockStatic(SecurityLogger.class);
-        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(mockSecurityAssertion);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(
+                mockSecurityAssertion);
         // SecurityLogger is already stubbed out
         when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
         when(mockSecurityToken.getToken()).thenReturn(null);
@@ -172,16 +177,16 @@ public class TestPepInterceptorActions {
         when(mockExchange.get(BindingOperationInfo.class)).thenReturn(mockBOI);
         when(mockBOI.getExtensor(SoapOperationInfo.class)).thenReturn(mockSOI);
         when(mockSOI.getAction()).thenReturn("urn:catalog:query:query-port:search");
-        
+
         doAnswer(new Answer<Boolean>() {
-			@Override
-			public Boolean answer(InvocationOnMock invocation) throws Throwable {
-				ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
-				assertEquals("urn:catalog:query:query-port:search", perm.getAction());
-				return true;
-			}
-		}).when(mockSubject).isPermitted(isA(ActionPermission.class));
-        
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
+                assertEquals("urn:catalog:query:query-port:search", perm.getAction());
+                return true;
+            }
+        }).when(mockSubject).isPermitted(isA(ActionPermission.class));
+
         // This should work.
         interceptor.handleMessage(messageWithAction);
 

--- a/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorActions.java
+++ b/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorActions.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Codice Foundation
+ * 
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ * 
+ **/
+package ddf.security.pep.interceptor;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.apache.cxf.binding.soap.model.SoapOperationInfo;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.ws.addressing.Names;
+import org.apache.cxf.ws.security.tokenstore.SecurityToken;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import ddf.security.Subject;
+import ddf.security.assertion.SecurityAssertion;
+import ddf.security.common.audit.SecurityLogger;
+import ddf.security.permission.ActionPermission;
+import ddf.security.service.SecurityManager;
+import ddf.security.service.SecurityServiceException;
+import ddf.security.service.impl.SecurityAssertionStore;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ SecurityAssertionStore.class, SecurityLogger.class })
+public class TestPepInterceptorActions {
+
+    @Test
+    public void testMessageWithNoServiceModelAction() throws SecurityServiceException {
+        PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+
+        SecurityManager mockSecurityManager = mock(SecurityManager.class);
+        interceptor.setSecurityManager(mockSecurityManager);
+
+        Message messageWithAction = mock(Message.class);
+        SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+        SecurityToken mockSecurityToken = mock(SecurityToken.class);
+        Subject mockSubject = mock(Subject.class);
+        assertNotNull(mockSecurityAssertion);
+
+        PowerMockito.mockStatic(SecurityAssertionStore.class);
+        PowerMockito.mockStatic(SecurityLogger.class);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(mockSecurityAssertion);
+        // SecurityLogger is already stubbed out
+        when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
+        when(mockSecurityToken.getToken()).thenReturn(null);
+
+        when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+        
+        QName op = new QName("urn:catalog:query", "search", "ns1");
+        QName port = new QName("urn:catalog:query", "query-port", "ns1");
+        when(messageWithAction.get("javax.xml.ws.wsdl.operation")).thenReturn(op);
+        when(messageWithAction.get("javax.xml.ws.wsdl.port")).thenReturn(port);
+
+        Exchange mockExchange = mock(Exchange.class);
+        BindingOperationInfo mockBOI = mock(BindingOperationInfo.class);
+        when(messageWithAction.getExchange()).thenReturn(mockExchange);
+        when(mockExchange.get(BindingOperationInfo.class)).thenReturn(mockBOI);
+        when(mockBOI.getExtensor(SoapOperationInfo.class)).thenReturn(null);
+        
+        doAnswer(new Answer<Boolean>() {
+			@Override
+			public Boolean answer(InvocationOnMock invocation) throws Throwable {
+				ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
+				assertEquals("urn:catalog:query:query-port:searchRequest", perm.getAction());
+				return true;
+			}
+		}).when(mockSubject).isPermitted(isA(ActionPermission.class));
+        
+        // This should work.
+        interceptor.handleMessage(messageWithAction);
+
+        PowerMockito.verifyStatic();
+    }
+    
+    @Test
+    public void testMessageWithMessageAction() throws SecurityServiceException {
+        PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+
+        SecurityManager mockSecurityManager = mock(SecurityManager.class);
+        interceptor.setSecurityManager(mockSecurityManager);
+
+        Message messageWithAction = mock(Message.class);
+        SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+        SecurityToken mockSecurityToken = mock(SecurityToken.class);
+        Subject mockSubject = mock(Subject.class);
+        assertNotNull(mockSecurityAssertion);
+
+        PowerMockito.mockStatic(SecurityAssertionStore.class);
+        PowerMockito.mockStatic(SecurityLogger.class);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(mockSecurityAssertion);
+        // SecurityLogger is already stubbed out
+        when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
+        when(mockSecurityToken.getToken()).thenReturn(null);
+
+        when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+        
+		Map<QName, Object> extensionMap = new HashMap<>();
+		extensionMap.put(new QName(Names.WSA_NAMESPACE_WSDL_METADATA, Names.WSAW_ACTION_NAME),
+				"urn:catalog:query:query-port:search");
+		MessageInfo mockMessageInfo = mock(MessageInfo.class);
+		when(messageWithAction.get(MessageInfo.class.getName())).thenReturn(mockMessageInfo);
+		when(mockMessageInfo.getExtensionAttributes()).thenReturn(extensionMap);
+        
+        doAnswer(new Answer<Boolean>() {
+			@Override
+			public Boolean answer(InvocationOnMock invocation) throws Throwable {
+				ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
+				assertEquals("urn:catalog:query:query-port:search", perm.getAction());
+				return true;
+			}
+		}).when(mockSubject).isPermitted(isA(ActionPermission.class));
+        
+        // This should work.
+        interceptor.handleMessage(messageWithAction);
+
+        PowerMockito.verifyStatic();
+    }
+    
+
+    @Test
+    public void testMessageWithOperationAction() throws SecurityServiceException {
+        PEPAuthorizingInterceptor interceptor = new PEPAuthorizingInterceptor();
+
+        SecurityManager mockSecurityManager = mock(SecurityManager.class);
+        interceptor.setSecurityManager(mockSecurityManager);
+
+        Message messageWithAction = mock(Message.class);
+        SecurityAssertion mockSecurityAssertion = mock(SecurityAssertion.class);
+        SecurityToken mockSecurityToken = mock(SecurityToken.class);
+        Subject mockSubject = mock(Subject.class);
+        assertNotNull(mockSecurityAssertion);
+
+        PowerMockito.mockStatic(SecurityAssertionStore.class);
+        PowerMockito.mockStatic(SecurityLogger.class);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithAction)).thenReturn(mockSecurityAssertion);
+        // SecurityLogger is already stubbed out
+        when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
+        when(mockSecurityToken.getToken()).thenReturn(null);
+
+        when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
+
+        Exchange mockExchange = mock(Exchange.class);
+        BindingOperationInfo mockBOI = mock(BindingOperationInfo.class);
+        SoapOperationInfo mockSOI = mock(SoapOperationInfo.class);
+        when(messageWithAction.getExchange()).thenReturn(mockExchange);
+        when(mockExchange.get(BindingOperationInfo.class)).thenReturn(mockBOI);
+        when(mockBOI.getExtensor(SoapOperationInfo.class)).thenReturn(mockSOI);
+        when(mockSOI.getAction()).thenReturn("urn:catalog:query:query-port:search");
+        
+        doAnswer(new Answer<Boolean>() {
+			@Override
+			public Boolean answer(InvocationOnMock invocation) throws Throwable {
+				ActionPermission perm = (ActionPermission) invocation.getArguments()[0];
+				assertEquals("urn:catalog:query:query-port:search", perm.getAction());
+				return true;
+			}
+		}).when(mockSubject).isPermitted(isA(ActionPermission.class));
+        
+        // This should work.
+        interceptor.handleMessage(messageWithAction);
+
+        PowerMockito.verifyStatic();
+    }
+}

--- a/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorValidSubject.java
+++ b/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorValidSubject.java
@@ -14,29 +14,20 @@
  **/
 package ddf.security.pep.interceptor;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import javax.xml.namespace.QName;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Matchers.isA;
-
-import org.apache.cxf.interceptor.security.AccessDeniedException;
-import org.apache.cxf.headers.Header;
+import org.apache.cxf.binding.soap.model.SoapOperationInfo;
+import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
-
-import org.w3c.dom.Element;
-
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -75,15 +66,19 @@ public class TestPepInterceptorValidSubject {
 
         when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
         
-        Header mockHeader = mock(Header.class);
-        when(mockHeader.getName()).thenReturn(new QName("http://www.w3.org/2005/08/addressing", "Action"));
-        Element mockElement = mock(Element.class);
-        when(mockHeader.getObject()).thenReturn(mockElement);
-        when(mockElement.getTextContent()).thenReturn("");
-        List<Header> headerList = new ArrayList<Header>();
-        headerList.add(mockHeader);
-        when(messageWithValidSecurityAssertion.get(Header.HEADER_LIST)).thenReturn(headerList);
+        QName op = new QName("urn:catalog:query", "search", "ns1");
+        QName port = new QName("urn:catalog:query", "query-port", "ns1");
+        when(messageWithValidSecurityAssertion.get("javax.xml.ws.wsdl.operation")).thenReturn(op);
+        when(messageWithValidSecurityAssertion.get("javax.xml.ws.wsdl.port")).thenReturn(port);
+
+        Exchange mockExchange = mock(Exchange.class);
+        BindingOperationInfo mockBOI = mock(BindingOperationInfo.class);
+        when(messageWithValidSecurityAssertion.getExchange()).thenReturn(mockExchange);
+        when(mockExchange.get(BindingOperationInfo.class)).thenReturn(mockBOI);
+        when(mockBOI.getExtensor(SoapOperationInfo.class)).thenReturn(null);
+        
         when(mockSubject.isPermitted(isA(ActionPermission.class))).thenReturn(true);
+        
         // This should work.
         interceptor.handleMessage(messageWithValidSecurityAssertion);
 

--- a/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorValidSubject.java
+++ b/pep/security-pep-interceptor/src/test/java/ddf/security/pep/interceptor/TestPepInterceptorValidSubject.java
@@ -41,7 +41,7 @@ import ddf.security.service.SecurityServiceException;
 import ddf.security.service.impl.SecurityAssertionStore;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ SecurityAssertionStore.class, SecurityLogger.class })
+@PrepareForTest({SecurityAssertionStore.class, SecurityLogger.class})
 public class TestPepInterceptorValidSubject {
 
     @Test
@@ -59,13 +59,14 @@ public class TestPepInterceptorValidSubject {
 
         PowerMockito.mockStatic(SecurityAssertionStore.class);
         PowerMockito.mockStatic(SecurityLogger.class);
-        when(SecurityAssertionStore.getSecurityAssertion(messageWithValidSecurityAssertion)).thenReturn(mockSecurityAssertion);
+        when(SecurityAssertionStore.getSecurityAssertion(messageWithValidSecurityAssertion))
+                .thenReturn(mockSecurityAssertion);
         // SecurityLogger is already stubbed out
         when(mockSecurityAssertion.getSecurityToken()).thenReturn(mockSecurityToken);
         when(mockSecurityToken.getToken()).thenReturn(null);
 
         when(mockSecurityManager.getSubject(mockSecurityToken)).thenReturn(mockSubject);
-        
+
         QName op = new QName("urn:catalog:query", "search", "ns1");
         QName port = new QName("urn:catalog:query", "query-port", "ns1");
         when(messageWithValidSecurityAssertion.get("javax.xml.ws.wsdl.operation")).thenReturn(op);
@@ -76,9 +77,9 @@ public class TestPepInterceptorValidSubject {
         when(messageWithValidSecurityAssertion.getExchange()).thenReturn(mockExchange);
         when(mockExchange.get(BindingOperationInfo.class)).thenReturn(mockBOI);
         when(mockBOI.getExtensor(SoapOperationInfo.class)).thenReturn(null);
-        
+
         when(mockSubject.isPermitted(isA(ActionPermission.class))).thenReturn(true);
-        
+
         // This should work.
         interceptor.handleMessage(messageWithValidSecurityAssertion);
 


### PR DESCRIPTION
PEPAuthorizingInterceptor will now look at the service model for the action. It first looks at the message model for any Action attribute. If the Action isn't found in the message model, it'll look for the soapAction attribute in the operation model. If the service model doesn't contain any action metadata, then the action URI will be constructed from the WSDL port and operation names.
