### PR TITLE
Updated LDAP claims hander and login configs 

### DIFF
--- a/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -47,7 +47,7 @@
         <argument ref="encryptionService" />
         <argument ref="blueprintBundleContext" />
         <!-- Default properties -->
-        <property name="url" value="ldaps://localhost:1636" />
+        <property name="url" value="ldap://localhost:1389" />
         <property name="ldapBindUserDn" value="cn=admin" />
         <property name="password" value="ENC(c+GitDfYAMTDRESXSDDsMw==)" />
         <property name="userNameAttribute" value="uid" />

--- a/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/sts/security-sts-ldapclaimshandler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
 	 	name="Security STS LDAP and Roles Claims Handler" id="ddf.security.sts.claimsHandler">
 
 	    <AD name="LDAP URL:" id="url" required="true" type="String"
-	      default="ldaps://localhost:1636"
+	      default="ldap://localhost:1389"
 	      description="LDAP or LDAPS server and port">
 	    </AD>
 

--- a/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
+++ b/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/blueprint/karaf_ldap_config.xml
@@ -29,7 +29,7 @@
         <!-- Default properties -->
         <property name="ldapBindUserDn" value="cn=admin" />
         <property name="ldapBindUserPass" value="ENC(c+GitDfYAMTDRESXSDDsMw==)" />
-        <property name="ldapUrl" value="ldaps://localhost:1636" />
+        <property name="ldapUrl" value="ldap://localhost:1389" />
         <property name="userBaseDn" value="ou=users,dc=example,dc=com" />
         <property name="groupBaseDn" value="ou=groups,dc=example,dc=com" />
         <property name="keyAlias" value="localhost" />

--- a/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/sts/security-sts-ldaplogin/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -12,12 +12,14 @@
  *
  **/
 -->
-<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+<metatype:MetaData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.osgi.org/xmlns/metatype/v1.2.0 http://www.osgi.org/xmlns/metatype/v1.2.0"
+                   xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.2.0">
 
 	<OCD description="STS Ldap Login Configuration" name="Security STS LDAP Login" id="ddf.security.sts.ldap">
 	    
 	    <AD name="LDAP URL:" id="ldapUrl" required="true" type="String"
-	      default="ldaps://localhost:1636"
+	      default="ldap://localhost:1389"
 	      description="LDAP or LDAPS server and port">
 	    </AD>
 	    
@@ -26,7 +28,7 @@
 	      description="DN of the user to bind with LDAP. This user should have the ability to verify passwords and read attributes for any user.">
 	    </AD>
 	    
-	    <AD name="LDAP Bind User Password:" id="ldapBindUserPass" required="true" type="String"
+	    <AD name="LDAP Bind User Password:" id="ldapBindUserPass" required="true" type="Password"
 	      default="ENC(c+GitDfYAMTDRESXSDDsMw==)" 
 	      description="Password used to bind user with LDAP.">
 	    </AD>


### PR DESCRIPTION
- updated LDAP claims handler to use ldap by default instead of ldaps
- updated LDAP login to use ldap by default instead of ldaps
- updated LDAP login LDAP Bind User Password from String to Password type
